### PR TITLE
better regex for parameter parsing

### DIFF
--- a/compose-guard/core/src/main/kotlin/com/joetr/compose/guard/core/model/composables/ComposableDetail.kt
+++ b/compose-guard/core/src/main/kotlin/com/joetr/compose/guard/core/model/composables/ComposableDetail.kt
@@ -50,7 +50,13 @@ public data class ComposableDetail(
      * @property condition Stability condition of a parameter
      * @property details Name and type details of a parameter
      */
-    public data class Parameter(val condition: Condition, val stabilityStatus: StabilityStatus, val details: String) {
+    public data class Parameter(
+        val condition: Condition,
+        val stabilityStatus: StabilityStatus,
+        val details: String,
+        val unused: Boolean,
+        val raw: String,
+    ) {
         private val nameAndType by lazy {
             details.split(":").map { it.trim() }.let { (name, type) -> name to type }
         }

--- a/compose-guard/core/src/main/kotlin/com/joetr/compose/guard/core/parser/ComposableReportParser.kt
+++ b/compose-guard/core/src/main/kotlin/com/joetr/compose/guard/core/parser/ComposableReportParser.kt
@@ -82,7 +82,7 @@ public object ComposableReportParser : Parser<String, ComposablesReport> {
         return ComposablesReport(composables, errors.toList())
     }
 
-    internal fun getComposableFunctions(content: String): List<String> {
+    private fun getComposableFunctions(content: String): List<String> {
         val lines = content.split("\n").filter { it.isNotBlank() }
 
         val composableFunIndexes =

--- a/compose-guard/core/src/test/kotlin/com/joetr/compose/guard/core/ComposeCompilerMetricsProviderTest.kt
+++ b/compose-guard/core/src/test/kotlin/com/joetr/compose/guard/core/ComposeCompilerMetricsProviderTest.kt
@@ -132,8 +132,16 @@ class ComposeCompilerMetricsProviderTest {
                 it.stabilityStatus == StabilityStatus.MISSING
             }
 
+        val amountOfUnusedProperties =
+            metrics.getComposablesReport().composables.flatMap {
+                it.params
+            }.count {
+                it.unused
+            }
+
         assert(amountOfDynamicProperties == 1)
         assert(amountOfStaticProperties == 1)
         assert(amountOfMissingProperties == 1)
+        assert(amountOfUnusedProperties == 1)
     }
 }

--- a/compose-guard/gradle-plugin/src/functionalTest/kotlin/com/joetr/compose/guard/task/ComposeCompilerReportCheckTaskTest.kt
+++ b/compose-guard/gradle-plugin/src/functionalTest/kotlin/com/joetr/compose/guard/task/ComposeCompilerReportCheckTaskTest.kt
@@ -164,7 +164,7 @@ class ComposeCompilerReportCheckTaskTest {
         assertThat(
             checkResult.output,
         ).contains(
-            "FunctionAndParameter(functionName=TestComposable, parameterName=test, parameterType=Test? = @dynamic Test(\"default\"))",
+            "FunctionAndParameter(functionName=TestComposable, parameterName=test, parameterType=Test?)",
         )
         assertThat(checkResult).task(checkTask).failed()
     }


### PR DESCRIPTION
Old regex was relying on string contains calls to detect stuff. modified the regex to be more inclusive with better matching groups 

also modified unstable class check. before it was just a naïve if more classes existed in the check vs. golden, but that doesn't account for if golden has deleted classes and new classes are added in check.